### PR TITLE
Bugfix: use of an operand of type 'bool' in 'operator++' is forbidden in C++17

### DIFF
--- a/local-patches/gcc/4.8.5/0030-fix-reload1-compile-error.patch
+++ b/local-patches/gcc/4.8.5/0030-fix-reload1-compile-error.patch
@@ -1,0 +1,17 @@
+Avoid gcc/reload1.c compile error when building with newer gcc (e.g. gcc 11.2 on Ubuntu 21.10).
+
+The error was:
+
+.../esp-open-sdk/crosstool-NG/.build/src/gcc-4.8.5/gcc/reload1.c:89:24: error: use of an operand of type 'bool' in 'operator++' is forbidden in C++17
+
+--- gcc-4.8.5/gcc/reload1.c~	2013-01-21 06:55:05.000000000 -0800
++++ gcc-4.8.5/gcc/reload1.c	2022-01-05 17:18:10.148547719 -0800
+@@ -440,7 +440,7 @@
+ 
+   while (memory_address_p (QImode, tem))
+     {
+-      spill_indirect_levels++;
++      spill_indirect_levels = 1;
+       tem = gen_rtx_MEM (Pmode, tem);
+     }
+ 


### PR DESCRIPTION
I just applied the patch by ChrisMacGregor. See discussion [here](https://github.com/esp-open-sdk/esp-open-sdk/issues/10)